### PR TITLE
Extended residue numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 *.o
 *.obj
 obj/
-test_*
 
 ## Compiled Dynamic libraries
 *.so

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([dssp], [3.0.9], [Coos.Baakman@radboudumc.nl])
+AC_INIT([dssp], [3.1.1], [Coos.Baakman@radboudumc.nl])
 AM_INIT_AUTOMAKE([subdir-objects])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])

--- a/src/align-2d.h
+++ b/src/align-2d.h
@@ -39,24 +39,24 @@ struct entry
     , m_seq(seq)
     , m_weight(weight) {}
 
-  uint32 nr() const { return m_nr; }
+  int64 nr() const { return m_nr; }
   float weight() const { return m_weight; }
   uint32 length() const { return static_cast<uint32>(m_seq.length()); }
 
-  void insert_gap(uint32 pos);
+  void insert_gap(int64 pos);
   void append_gap();
 
-  void remove_gap(uint32 pos);
+  void remove_gap(int64 pos);
 
   void remove_gaps();
   void dump_positions() { m_positions.clear(); }
 
-  uint32 m_nr;
+  int64 m_nr;
   std::string m_id;
   sequence m_seq;
   sec_structure m_ss;
   float m_weight;
-  std::vector<int16> m_positions;
+  std::vector<int64> m_positions;
 };
 
 // --------------------------------------------------------------------

--- a/src/dssp.cpp
+++ b/src/dssp.cpp
@@ -34,12 +34,11 @@ std::string FixedLengthString(const int64 number, const uint64 length)
     std::string s = std::to_string(number);
 
     if (s.length() < length)
-        s = s.insert(0, length - s.length, ' ');
+        s = s.insert(0, length - s.length(), ' ');
     else if (s.length() > length)
     {
         // make and arrow: "--->"
-        s = s.replace(s.end() - 1, 1, '>');
-        s = s.replace(0, s.end() - 1, '-');
+        s = std::string(length - 1, '-') + ">";
     }
     return s;
 }
@@ -120,6 +119,7 @@ std::string ResidueToDSSPLine(const MResidue& residue)
   for (uint32 i = 0; i < 2; ++i)
   {
     NHO[i] = ONH[i] = "0, 0.0";
+    nNHO[i] = nONH[i] = 0;
 
     if (acceptors[i].residue != nullptr)
     {

--- a/src/dssp.cpp
+++ b/src/dssp.cpp
@@ -53,7 +53,7 @@ std::string ResidueToDSSPLine(const MResidue& residue)
   #  RESIDUE AA STRUCTURE BP1 BP2  ACC     N-H-->O    O-->H-N    N-H-->O    O-->H-N    TCO  KAPPA ALPHA  PHI   PSI    X-CA   Y-CA   Z-CA           CHAIN AUTHCHAIN
  */
   boost::format kDSSPResidueLine(
-  "%5.5s%5.5s%1.1s%1.1s %c  %c %c%c%c%c%c%c%c%4.4s%4.4s%c%4.4s %11s%11s%11s%11s  %6.3f%6.1f%6.1f%6.1f%6.1f %6.1f %6.1f %6.1f             %4.4s      %4.4s");
+  "%5.5s%5.5s%1.1s%1.1s %c  %c %c%c%c%c%c%c%c%4.4s%4.4s%c%4.4s %11s%11s%11s%11s  %6.3f%6.1f%6.1f%6.1f%6.1f %6.1f %6.1f %6.1f             %4.4s      %4.4s %10s %10s %10s %10s %10s %10s %10s %10s");
 
   const MAtom& ca = residue.GetCAlpha();
 
@@ -102,7 +102,7 @@ std::string ResidueToDSSPLine(const MResidue& residue)
     MBridgeParner p = residue.GetBetaPartner(i);
     if (p.residue != nullptr)
     {
-      bp[i] = FixedLengthString(p.residue->GetNumber(), 4);
+      bp[i] = p.residue->GetNumber();
       bridgelabel[i] = 'A' + p.ladder % 26;
       if (p.parallel)
         bridgelabel[i] = tolower(bridgelabel[i]);
@@ -114,6 +114,7 @@ std::string ResidueToDSSPLine(const MResidue& residue)
     sheet = 'A' + (residue.GetSheet() - 1) % 26;
 
   std::string NHO[2], ONH[2];
+  int64 nNHO[2], nONH[2];
   const HBond* acceptors = residue.Acceptor();
   const HBond* donors = residue.Donor();
   for (uint32 i = 0; i < 2; ++i)
@@ -122,14 +123,14 @@ std::string ResidueToDSSPLine(const MResidue& residue)
 
     if (acceptors[i].residue != nullptr)
     {
-      int32 d = acceptors[i].residue->GetNumber() - residue.GetNumber();
-      NHO[i] = (boost::format("%s,%3.1f") % FixedLengthString(d, 5) % acceptors[i].energy).str();
+      nNHO[i] = acceptors[i].residue->GetNumber() - residue.GetNumber();
+      NHO[i] = (boost::format("%s,%3.1f") % FixedLengthString(nNHO[i], 5) % acceptors[i].energy).str();
     }
 
     if (donors[i].residue != nullptr)
     {
-      int32 d = donors[i].residue->GetNumber() - residue.GetNumber();
-      ONH[i] = (boost::format("%s,%3.1f") % FixedLengthString(d, 5) % donors[i].energy).str();
+      nONH[i] = donors[i].residue->GetNumber() - residue.GetNumber();
+      ONH[i] = (boost::format("%s,%3.1f") % FixedLengthString(nONH[i], 5) % donors[i].energy).str();
     }
   }
 
@@ -146,10 +147,14 @@ std::string ResidueToDSSPLine(const MResidue& residue)
   return (kDSSPResidueLine % FixedLengthString(residue.GetNumber(), 5) % FixedLengthString(ca.mResSeq, 5) %
     ca.mICode % chainChar % code %
     ss % helix[0] % helix[1] % helix[2] % bend % chirality % bridgelabel[0] % bridgelabel[1] %
-    bp[0] % bp[1] % sheet % FixedLengthString(floor(residue.Accessibility() + 0.5), 4) %
+    FixedLengthString(bp[0], 4) % FixedLengthString(bp[1], 4) % sheet % FixedLengthString(floor(residue.Accessibility() + 0.5), 4) %
     NHO[0] % ONH[0] % NHO[1] % ONH[1] %
     residue.TCO() % residue.Kappa() % alpha % residue.Phi() % residue.Psi() %
-    ca.mLoc.mX % ca.mLoc.mY % ca.mLoc.mZ % long_ChainID1 % long_ChainID2).str();
+    ca.mLoc.mX % ca.mLoc.mY % ca.mLoc.mZ % long_ChainID1 % long_ChainID2 %
+    FixedLengthString(residue.GetNumber(), 10) % FixedLengthString(ca.mResSeq, 10) %
+    FixedLengthString(bp[0], 10) % FixedLengthString(bp[1], 10) %
+    FixedLengthString(nNHO[0], 10) % FixedLengthString(nONH[0], 10) % FixedLengthString(nNHO[1], 10) % FixedLengthString(nONH[1], 10)
+  ).str();
 }
 
 void WriteDSSP(MProtein& protein, std::ostream& os)
@@ -236,7 +241,7 @@ void WriteDSSP(MProtein& protein, std::ostream& os)
 
   // per residue information
 
-  os << "  #  RESIDUE AA STRUCTURE BP1 BP2  ACC     N-H-->O    O-->H-N    N-H-->O    O-->H-N    TCO  KAPPA ALPHA  PHI   PSI    X-CA   Y-CA   Z-CA            CHAIN AUTHCHAIN" << std::endl;
+  os << "  #  RESIDUE AA STRUCTURE BP1 BP2  ACC     N-H-->O    O-->H-N    N-H-->O    O-->H-N    TCO  KAPPA ALPHA  PHI   PSI    X-CA   Y-CA   Z-CA            CHAIN AUTHCHAIN     NUMBER     RESNUM        BP1        BP2    N-H-->O    O-->H-N    N-H-->O    O-->H-N" << std::endl;
   boost::format kDSSPResidueLine(
     "%5.5s        !%c             0   0    0      0, 0.0     0, 0.0     0, 0.0     0, 0.0   0.000 360.0 360.0 360.0 360.0    0.0    0.0    0.0");
 

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -980,7 +980,7 @@ void MChain::WritePDB(std::ostream& os)
   os << (ter % (last->GetCAlpha().mSerial + 1) % kResidueInfo[last->GetType()].name % mChainID % last->GetNumber() % ' ') << std::endl;
 }
 
-const MResidue* MChain::GetResidueBySeqNumber(uint16 inSeqNumber,
+const MResidue* MChain::GetResidueBySeqNumber(int64 inSeqNumber,
                                               const std::string& inInsertionCode) const
 {
   const auto r = find_if(mResidues.begin(), mResidues.end(),
@@ -1160,12 +1160,12 @@ void MProtein::ReadPDB(std::istream& is, bool cAlphaOnly)
       std::pair<MResidueID,MResidueID> ssbond;
 
       ssbond.first.chain = line[15];
-      ssbond.first.seqNumber = boost::lexical_cast<uint16>(
+      ssbond.first.seqNumber = boost::lexical_cast<int64>(
           ba::trim_copy(line.substr(16, 5)));
       ssbond.first.insertionCode = line[21];
 
       ssbond.second.chain = line[29];
-      ssbond.second.seqNumber = boost::lexical_cast<uint16>(
+      ssbond.second.seqNumber = boost::lexical_cast<int64>(
           ba::trim_copy(line.substr(30, 5)));
       ssbond.second.insertionCode = line[35];
 
@@ -1220,7 +1220,7 @@ void MProtein::ReadPDB(std::istream& is, bool cAlphaOnly)
       atom.mChainID = line[21];
       atom.mAuthChainID = atom.mChainID;
       //  23 - 26  Integer resSeq Residue sequence number.
-      atom.mResSeq = boost::lexical_cast<int16>(
+      atom.mResSeq = boost::lexical_cast<int64>(
           ba::trim_copy(line.substr(22, 4)));
       //  27    AChar iCode Code for insertion of residues.
       atom.mICode = line.substr(26, 1);
@@ -1442,7 +1442,7 @@ void MProtein::ReadmmCIF(std::istream& is, bool cAlphaOnly)
       continue;
 
     ssbond.second.chain = ss["ptnr2_label_asym_id"];
-    ssbond.second.seqNumber = boost::lexical_cast<uint16>(
+    ssbond.second.seqNumber = boost::lexical_cast<int64>(
         ss["ptnr2_label_seq_id"]);
     ssbond.second.insertionCode = ss["pdbx_ptnr2_PDB_ins_code"];
     if (ssbond.second.insertionCode == "?")
@@ -1455,7 +1455,7 @@ void MProtein::ReadmmCIF(std::istream& is, bool cAlphaOnly)
   char firstAltLoc = 0;
 
   // remap label_seq_id to auth_seq_id
-  std::map<std::string, std::map<int,int> > seq_id_map;
+  std::map<std::string, std::map<int64,int64> > seq_id_map;
 
   bool hasModelNum = false;
   int modelNum = 0;
@@ -1488,7 +1488,7 @@ void MProtein::ReadmmCIF(std::istream& is, bool cAlphaOnly)
     if (label_seq_id == "?" or label_seq_id == ".")
       seq_id_map[a.mChainID][a.mResSeq] = a.mResSeq;
     else
-      seq_id_map[a.mChainID][boost::lexical_cast<int16>(label_seq_id)] = a.mResSeq;
+      seq_id_map[a.mChainID][boost::lexical_cast<int64>(label_seq_id)] = a.mResSeq;
 
     a.mLoc.mX = ParseFloat(atom["Cartn_x"]);
     a.mLoc.mY = ParseFloat(atom["Cartn_y"]);
@@ -1647,7 +1647,7 @@ void MProtein::GetStatistics(uint32& outNrOfResidues, uint32& outNrOfChains,
         if (donor[i].residue != nullptr and donor[i].energy < kMaxHBondEnergy)
         {
           ++outNrOfHBonds;
-          int32 k = donor[i].residue->GetNumber() - r->GetNumber();
+          int64 k = donor[i].residue->GetNumber() - r->GetNumber();
           if (k >= -5 and k <= 5)
             outNrOfHBondsPerDistance[k + 5] += 1;
         }
@@ -1725,7 +1725,7 @@ void MProtein::AddResidue(const std::vector<MAtom>& inAtoms)
     if (not residues.empty())
       prev = residues.back();
 
-    int32 resNumber = mResidueCount + mChains.size() + mChainBreaks;
+    int64 resNumber = mResidueCount + mChains.size() + mChainBreaks;
     MResidue* r = new MResidue(resNumber, prev, inAtoms);
     // check for chain breaks
     if (prev != nullptr and not prev->ValidDistance(*r))
@@ -2254,7 +2254,7 @@ void MProtein::SetChain(const std::string& inChainID, const MChain& inChain)
 
 // Non-const overload, implemented in terms of the const overload
 MResidue* MProtein::GetResidue(const std::string& inChainID,
-                               uint16 inSeqNumber,
+                               int64 inSeqNumber,
                                const std::string& inInsertionCode)
 {
   return const_cast<MResidue *>( static_cast<const MProtein &>( *this ).GetResidue(
@@ -2266,7 +2266,7 @@ MResidue* MProtein::GetResidue(const std::string& inChainID,
 
 // Const overload
 const MResidue* MProtein::GetResidue(const std::string& inChainID,
-                                     uint16 inSeqNumber,
+                                     int64 inSeqNumber,
                                      const std::string& inInsertionCode) const
 {
   const MChain& chain = GetChain(inChainID);
@@ -2287,7 +2287,7 @@ void MProtein::GetCAlphaLocations(const std::string& inChainID,
 }
 
 MPoint MProtein::GetCAlphaPosition(const std::string& inChainID,
-                                   int16 inPDBResSeq) const
+                                   int64 inPDBResSeq) const
 {
   std::string chainID = inChainID;
   if (chainID.empty())

--- a/src/structure.h
+++ b/src/structure.h
@@ -225,11 +225,11 @@ class MResidue
   // bridge functions
   MBridgeType      TestBridge(MResidue* inResidue) const;
 
-  int16        GetSeqNumber() const    { return mSeqNumber; }
+  int64        GetSeqNumber() const    { return mSeqNumber; }
   std::string      GetInsertionCode() const  { return mInsertionCode; }
 
-  void        SetNumber(uint16 inNumber)  { mNumber = inNumber; }
-  uint16        GetNumber() const      { return mNumber; }
+  void        SetNumber(uint64 inNumber)  { mNumber = inNumber; }
+  int64        GetNumber() const      { return mNumber; }
 
   void        Translate(const MPoint& inTranslation);
   void        Rotate(const MQuaternion& inRotation);
@@ -265,7 +265,7 @@ class MResidue
   std::string      mChainID;
   MResidue*      mPrev;
   MResidue*      mNext;
-  int32        mSeqNumber, mNumber;
+  int64        mSeqNumber, mNumber;
   std::string      mInsertionCode;
   MResidueType    mType;
   uint8        mSSBridgeNr;
@@ -302,7 +302,7 @@ class MChain
   std::string GetAuthChainID(void) const;
   void SetAuthChainID(const std::string &inAuthChainID);
 
-  const MResidue*      GetResidueBySeqNumber(uint16 inSeqNumber,
+  const MResidue*      GetResidueBySeqNumber(int64 inSeqNumber,
                                              const std::string& inInsertionCode) const;
 
   void        GetSequence(std::string& outSequence) const;
@@ -354,7 +354,7 @@ class MProtein
   void GetCAlphaLocations(const std::string& inChainID,
                                  std::vector<MPoint>& outPoints) const;
   MPoint        GetCAlphaPosition(const std::string& inChainID,
-                                  int16 inPDBResSeq) const;
+                                  int64 inPDBResSeq) const;
 
   void        GetSequence(const std::string& inChainID,
                           entry& outEntry) const;
@@ -384,10 +384,10 @@ class MProtein
   template<class OutputIterator>
   void        GetSequences(OutputIterator outSequences) const;
 
-  MResidue* GetResidue(const std::string& inChainID, uint16 inSeqNumber,
+  MResidue* GetResidue(const std::string& inChainID, int64 inSeqNumber,
                        const std::string& inInsertionCode);
 
-  const MResidue* GetResidue(const std::string& inChainID, uint16 inSeqNumber,
+  const MResidue* GetResidue(const std::string& inChainID, int64 inSeqNumber,
                              const std::string& inInsertionCode) const;
 
   // statistics

--- a/tests/test_readpdb.cpp
+++ b/tests/test_readpdb.cpp
@@ -1,0 +1,148 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE ReadPDB
+
+#include "structure.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <sstream>
+
+namespace xssp { namespace test { } }
+
+using namespace xssp::test;
+
+using std::istream;
+using std::istringstream;
+using std::string;
+
+namespace xssp {
+  namespace test {
+
+    class readpdb_fixture {
+    protected:
+      ~readpdb_fixture() noexcept = default;
+
+      /// \brief Read an istream of PDB data into an MProtein and return it
+      ///
+      /// This may become redundant if MProtein's interface is changed to provide this directly
+      static MProtein ReadPDBIntoMProtein(std::istream &argIs ///< The istream of PDB data to parse
+                                          ) {
+        MProtein theProtein;
+        theProtein.ReadPDB( argIs );
+        return theProtein;
+      }
+
+      /// \brief Get the number of residues in the specified MProtein
+      ///
+      /// This may become redundant if the MProtein's interface is changed to provide this directly
+      static uint32 getNrOfResidues(const MProtein &argProtein ///< The MProtein to query
+                                    ) {
+        uint32 nrOfResidues, nrOfChains, nrOfSSBridges, nrOfIntraChainSSBridges, nrOfHBonds;
+        uint32 nrOfHBondsPerDistance[11] = {};
+        argProtein.GetStatistics(nrOfResidues, nrOfChains, nrOfSSBridges, nrOfIntraChainSSBridges, nrOfHBonds, nrOfHBondsPerDistance);
+        return nrOfResidues;
+      }
+
+      /// \brief Perform Boost Test assertions that the specified residue is present in the specified protein
+      ///
+      /// This checks that getting the residue doesn't throw, which is the current way of indicating absence.
+      /// It also checks the result isn't a nullptr, in case that behvaiour is changed.
+      static void checkResidueIsPresent(const MProtein &argProtein,            ///< The protein to query
+                                        const string   &argChainID,            ///< The chain ID of the residue to check
+                                        const uint16   &argSeqNumber,          ///< The seq number of the residue to check
+                                        const string   &argInsertionCode = " " ///< The insertion code of the residue to check
+                                                                               ///<   (with  adefault of " " for empty insert code)
+                                        ) {
+        BOOST_REQUIRE_NO_THROW( argProtein.GetResidue( argChainID, argSeqNumber, argInsertionCode )            );
+        BOOST_CHECK           ( argProtein.GetResidue( argChainID, argSeqNumber, argInsertionCode ) != nullptr );
+      }
+    };
+
+  }
+}
+
+
+
+BOOST_FIXTURE_TEST_SUITE(readpdb_test_suite, readpdb_fixture)
+
+
+
+BOOST_AUTO_TEST_CASE(parses_four_normal_residues)
+{
+  // Given: this raw data
+  istringstream raw_pdb_data_ss{ R"(ATOM      1  N   PRO A   1       3.069   2.269 -37.532  1.00 45.60           N  
+ATOM      2  CA  PRO A   1       3.988   2.650 -36.447  1.00 44.31           C  
+ATOM      3  C   PRO A   1       3.746   1.828 -35.194  1.00 38.99           C  
+ATOM      4  O   PRO A   1       2.578   1.409 -35.069  1.00 44.26           O  
+ATOM      8  N   PRO A   2       4.679   1.563 -34.283  1.00 33.16           N  
+ATOM      9  CA  PRO A   2       4.222   0.910 -33.032  1.00 28.69           C  
+ATOM     10  C   PRO A   2       3.183   1.806 -32.357  1.00 24.26           C  
+ATOM     11  O   PRO A   2       3.215   3.030 -32.488  1.00 26.34           O  
+ATOM     15  N   GLY A   3       2.280   1.100 -31.665  1.00 20.53           N  
+ATOM     16  CA  GLY A   3       1.219   1.833 -30.986  1.00 17.75           C  
+ATOM     17  C   GLY A   3       1.770   2.570 -29.801  1.00 15.03           C  
+ATOM     18  O   GLY A   3       2.952   2.505 -29.471  1.00 17.11           O  
+ATOM     19  N   PRO A   4       0.904   3.267 -29.124  1.00 14.96           N  
+ATOM     20  CA  PRO A   4       1.397   4.003 -27.950  1.00 14.56           C  
+ATOM     21  C   PRO A   4       1.644   3.066 -26.798  1.00 12.09           C  
+ATOM     22  O   PRO A   4       1.184   1.937 -26.714  1.00 12.02           O  
+)" };
+
+  // When: parsing the data into a MProtein
+  const MProtein theProtein = ReadPDBIntoMProtein( raw_pdb_data_ss );
+
+  // Then: the resulting MProtein should have 4 residues: A:1, A:2, A:3, A:4
+  BOOST_CHECK_EQUAL( getNrOfResidues( theProtein ), 4 );
+  checkResidueIsPresent( theProtein, "A", 1 );
+  checkResidueIsPresent( theProtein, "A", 2 );
+  checkResidueIsPresent( theProtein, "A", 3 );
+  checkResidueIsPresent( theProtein, "A", 4 );
+}
+
+
+
+// Test the issue documented in https://github.com/cmbi/xssp/issues/79
+//
+// Residue 124's ATOM records were being ignored because the code didn't
+// adequately reset after rejecting the residue 123's ATOM records.
+BOOST_AUTO_TEST_CASE(includes_valid_altlocn_residue_after_rejecting_altlocn_residue)
+{
+  // Given: this raw data
+  istringstream raw_pdb_data_ss{ R"(ATOM   1032  N   MET A 120      23.127   5.241  -5.234  1.00  9.79           N  
+ATOM   1033  CA  MET A 120      24.061   4.468  -6.042  1.00  9.61           C  
+ATOM   1034  C   MET A 120      24.811   3.451  -5.187  1.00  9.38           C  
+ATOM   1035  O   MET A 120      25.054   2.306  -5.620  1.00 10.06           O  
+ATOM   1065  N  BGLN A 123      22.567   0.603  -4.409  1.00 11.11           N  
+ATOM   1066  CA BGLN A 123      22.431  -0.200  -5.625  1.00 11.15           C  
+ATOM   1067  C  BGLN A 123      23.706  -0.950  -5.973  1.00 10.67           C  
+ATOM   1068  O  BGLN A 123      23.706  -1.700  -6.955  1.00 11.70           O  
+ATOM   1074  N  ALYS A 124      24.772  -0.666  -5.315  0.64  9.24           N  
+ATOM   1075  N  BLYS A 124      24.774  -0.724  -5.226  0.36 10.75           N  
+ATOM   1076  CA ALYS A 124      26.058  -1.322  -5.576  0.64  9.02           C  
+ATOM   1077  CA BLYS A 124      26.116  -1.237  -5.480  0.36 10.92           C  
+ATOM   1078  C  ALYS A 124      26.612  -0.964  -6.962  0.64  9.77           C  
+ATOM   1079  C  BLYS A 124      26.599  -0.944  -6.904  0.36  9.69           C  
+ATOM   1080  O  ALYS A 124      27.304  -1.768  -7.599  0.64 11.47           O  
+ATOM   1081  O  BLYS A 124      27.229  -1.776  -7.565  0.36 11.86           O  
+ATOM   1092  N   ARG A 125      26.324   0.274  -7.353  1.00  9.58           N  
+ATOM   1093  CA  ARG A 125      26.849   0.839  -8.587  1.00 10.21           C  
+ATOM   1094  C   ARG A 125      28.105   1.626  -8.216  1.00  9.67           C  
+ATOM   1095  O   ARG A 125      28.075   2.852  -8.074  1.00 10.39           O  
+)"
+  };
+
+  // When: parsing the data into a MProtein
+  const MProtein theProtein = ReadPDBIntoMProtein( raw_pdb_data_ss );
+
+  // Then: the resulting MProtein should have at least 3 residues
+  // (but accept more in case A:123 is accepted in the future)
+  // including A:120, A:124 and A:125
+  BOOST_CHECK_GE( getNrOfResidues( theProtein ), 3 );
+  checkResidueIsPresent( theProtein, "A", 120 );
+  checkResidueIsPresent( theProtein, "A", 124 );
+  checkResidueIsPresent( theProtein, "A", 125 );
+}
+
+
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Limit the string length for residue numbers, so that the columns don't get shifted to the right.
Also, make columns on the right that contain the full residue numbers.

Affected columns:
- residue numbers
- bp1 and bp2
- NHO and OHN hydrogen bond residue numbers