### PR TITLE
fix inconsistency in ACC calculation for PDB without element type field

### DIFF
--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -1284,7 +1284,14 @@ void MProtein::ReadPDB(std::istream& is, bool cAlphaOnly)
         atom.mType = kUnknownAtom;
       }
 
-      if (atom.mType == kHydrogen)
+      /* As of dssp-3.1.4, lines with Element symbol H at positions 77-78
+       * will be skipped. This could potentially create inconsistent ACC if a
+       * line has <=76 characters (but >=54 characters and is therefore legal
+       * PDB format. To fix this issue, we should judge element type by
+       * [1] atom.mType at position 77-78, or
+       * [2] (in case [1] is undefined), atom.mName at position 13-16 */
+      if (atom.mType == kHydrogen || (atom.mType==kUnknownAtom && 
+          atom.mName[0]=='H'))
         continue;
 
       prevAtom = atom;


### PR DESCRIPTION
dssp does not return the same solvent accessibility result for PDB with and without element type (column 77-78 in ATOM/HETATM line). This is because dssp skip lines with >=78 characters and have element type H. For PDB file with ATOM/HETAM lines that has <78 characters (but >=54 characters), all lines would have been read regardless of element type. To reproduce this behavior on dssp-3.1.4:

```bash
mkdssp -i 1ank.pdb -o 1ank.dssp
cut -c1-54 1ank.pdb > 1-54.pdb
mkdssp -i 1-54.pdb -o 1-54.dssp
```
1ank.dssp and 1-54.pdb will have different ACC. With the patch in this pull request, they will have the same ACC.
