### PR TITLE
Update Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -42,7 +42,7 @@ test_readpdb_SOURCES	=	src/iocif.cpp \
 test_readpdb_LDADD	=	$(shared_LDADD) \
 									$(BOOST_UNIT_TEST_FRAMEWORK_LIB)
 
-AM_CPPFLAGS	=	-std=c++11 \
+AM_CPPFLAGS	=	-std=c++14 \
 							-pedantic \
 							-Wall \
 							-Werror \


### PR DESCRIPTION
The minimum language standard for `Boost.Math` will be C++14 starting in July 2023 (Boost 1.82 release). Warning causes compilation to fail.